### PR TITLE
Add usage guides for each set of tests

### DIFF
--- a/6502/README.md
+++ b/6502/README.md
@@ -36,6 +36,8 @@ Then for each test:
 
 If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
 
+If you do perform step #3, also ensure only **one** bus operation occurs per cycle.
+
 ## Example
 
 Below is an example of a single test:

--- a/6502/README.md
+++ b/6502/README.md
@@ -1,57 +1,86 @@
 # 6502
 
-10,000 tests are provided per opcode. All tests assume a full 64kb of RAM is mapped to the processor.
+Test data for the MOS 6502 microprocessor.
 
-Sample test:
+For NES-specific tests, refer to [nes6502](../nes6502/) instead.
 
-	{
-		"name": "b1 28 b5",
-		"initial": {
-			"pc": 59082,
-			"s": 39,
-			"a": 57,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[40, 160],
-				[41, 233],
-				[59982, 119]
-			]
-		},
-		"final": {
-			"pc": 59084,
-			"s": 39,
-			"a": 119,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[40, 160],
-				[41, 233],
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[59982, 119]
-			]
-		},
-		"cycles": [
-			[59082, 177, "read"],
-			[59083, 40, "read"],
-			[40, 160, "read"],
-			[41, 233, "read"],
-			[59083, 40, "read"],
-			[59982, 119, "read"]
+# Guide
+
+Within each `.json` file, there is a JSON array of 10,000 test scenarios.
+
+Each file corresponds to each of the instruction opcodes. (e.g. `a9.json` stores all of the tests for the LDA immediate instruction)
+
+Each test contains a `name` string, which can be ignored, and three major sections:
+* `initial` - the initial state of the processor
+* `final` - the expected final state of the processor
+* `cycles` - a list of expected bus operations for each cycle of the instruction
+  * each cycle is in the form of `[address, value, type]` where `type` is either `"read"` or `"write"`
+
+## Memory
+
+All tests assume the entire 64KiB memory space is RAM. In order to perform these tests, you may need to write a separate memory map for your emulator.
+
+The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
+
+Memory at any address besides those listed in the test, are expected to contain zeros.
+
+## Test Procedure
+
+First use a JSON parser to parse one of the `.json` files into an array/list of individual tests.
+
+Then for each test:
+1. Initialize your emulator's processor and memory with the `initial` state data provided by the test.
+2. Step your emulator forward until the processor completes **one instruction** worth of cycles.
+3. (Optional) After each cycle, compare your processor's last bus operation against the corresponding cycle from the `cycles` list.
+4. Once the instruction is complete, compare the test's expected `final` state with your emulator's state. If everything matches, you've passed the test!
+
+If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
+
+## Example
+
+Below is an example of a single test:
+```JSON
+{
+	"name": "b1 28 b5",
+	"initial": {
+		"pc": 59082,
+		"s": 39,
+		"a": 57,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[40, 160],
+			[41, 233],
+			[59982, 119]
 		]
-	}
-
-`name` is provided for human consumption and has no formal meaning.
-
-`initial` is the initial state of the processor; `ram` contains a list of values to store in memory prior to execution, each one in the form `[address, value]`.
-
-`final` is the state of the processor and relevant memory contents after execution.
-
-`cycles` provides a cycle-by-cycle breakdown of bus activity in the form `[address, value, type]` where `type` is either `read` or `write`.
+	},
+	"final": {
+		"pc": 59084,
+		"s": 39,
+		"a": 119,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[40, 160],
+			[41, 233],
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[59982, 119]
+		]
+	},
+	"cycles": [
+		[59082, 177, "read"],
+		[59083, 40, "read"],
+		[40, 160, "read"],
+		[41, 233, "read"],
+		[59083, 40, "read"],
+		[59982, 119, "read"]
+	]
+}
+```

--- a/nes6502/README.md
+++ b/nes6502/README.md
@@ -38,6 +38,8 @@ Then for each test:
 
 If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
 
+If you do perform step #3, also ensure only **one** bus operation occurs per cycle.
+
 ## Example
 
 Below is an example of a single test:

--- a/nes6502/README.md
+++ b/nes6502/README.md
@@ -1,61 +1,90 @@
 # NES 6502
 
-The NES 6502 is a version of the 6502 that ignores the state of the decimal flag when performing arithmetic.
+Test data for the 6502-derived CPU core contained within the RP2A03 microprocessor used by the NES.
 
-10,000 tests are provided per opcode. All tests assume a full 64kb of uniquely-mapped RAM is mapped to the processor; **this deviates from the actual memory layout of a NES** regardless of the cartridge in use.
+This version of the 6502 disabled the binary-coded decimal mode.
 
-Sample test:
+For tests of the original 6502, refer to [6502](../6502/) instead.
 
-	{
-		"name": "b1 71 8b",
-		"initial": {
-			"pc": 9023,
-			"s": 240,
-			"a": 47,
-			"x": 162,
-			"y": 170,
-			"p": 170,
-			"ram": [
-				[9023, 177],
-				[9024, 113],
-				[9025, 139],
-				[113, 169],
-				[114, 89],
-				[22867, 214],
-				[23123, 37]
-			]
-		},
-		"final": {
-			"pc": 9025,
-			"s": 240,
-			"a": 37,
-			"x": 162,
-			"y": 170,
-			"p": 40,
-			"ram": [
-				[113, 169],
-				[114, 89],
-				[9023, 177],
-				[9024, 113],
-				[9025, 139],
-				[22867, 214],
-				[23123, 37]
-			]
-		},
-		"cycles": [
-			[9023, 177, "read"],
-			[9024, 113, "read"],
-			[113, 169, "read"],
-			[114, 89, "read"],
-			[22867, 214, "read"],
-			[23123, 37, "read"]
+# Guide
+
+Within each `.json` file, there is a JSON array of 10,000 test scenarios.
+
+Each file corresponds to each of the instruction opcodes. (e.g. `a9.json` stores all of the tests for the LDA immediate instruction)
+
+Each test contains a `name` string, which can be ignored, and three major sections:
+* `initial` - the initial state of the processor
+* `final` - the expected final state of the processor
+* `cycles` - a list of expected bus operations for each cycle of the instruction
+  * each cycle is in the form of `[address, value, type]` where `type` is either `"read"` or `"write"`
+
+## Memory
+
+All tests assume the entire 64KiB memory space is RAM. Since this is different from the memory layout of the NES, you _must_ write a separate memory map for your emulator in order to perform these tests.
+
+The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
+
+Memory at any address besides those listed in the test, are expected to contain zeros.
+
+## Test Procedure
+
+First use a JSON parser to parse one of the `.json` files into an array/list of individual tests.
+
+Then for each test:
+1. Initialize your emulator's processor and memory with the `initial` state data provided by the test.
+2. Step your emulator forward until the processor completes **one instruction** worth of cycles.
+3. (Optional) After each cycle, compare your processor's last bus operation against the corresponding cycle from the `cycles` list.
+4. Once the instruction is complete, compare the test's expected `final` state with your emulator's state. If everything matches, you've passed the test!
+
+If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
+
+## Example
+
+Below is an example of a single test:
+```JSON
+{
+	"name": "b1 71 8b",
+	"initial": {
+		"pc": 9023,
+		"s": 240,
+		"a": 47,
+		"x": 162,
+		"y": 170,
+		"p": 170,
+		"ram": [
+			[9023, 177],
+			[9024, 113],
+			[9025, 139],
+			[113, 169],
+			[114, 89],
+			[22867, 214],
+			[23123, 37]
 		]
-	}
-
-`name` is provided for human consumption and has no formal meaning.
-
-`initial` is the initial state of the processor; `ram` contains a list of values to store in memory prior to execution, each one in the form `[address, value]`.
-
-`final` is the state of the processor and relevant memory contents after execution.
-
-`cycles` provides a cycle-by-cycle breakdown of bus activity in the form `[address, value, type]` where `type` is either `read` or `write`.
+	},
+	"final": {
+		"pc": 9025,
+		"s": 240,
+		"a": 37,
+		"x": 162,
+		"y": 170,
+		"p": 40,
+		"ram": [
+			[113, 169],
+			[114, 89],
+			[9023, 177],
+			[9024, 113],
+			[9025, 139],
+			[22867, 214],
+			[23123, 37]
+		]
+	},
+	"cycles": [
+		[9023, 177, "read"],
+		[9024, 113, "read"],
+		[113, 169, "read"],
+		[114, 89, "read"],
+		[22867, 214, "read"],
+		[23123, 37, "read"]
+	]
+}
+```

--- a/rockwell65c02/README.md
+++ b/rockwell65c02/README.md
@@ -1,59 +1,86 @@
 # Rockwell 65C02
 
-The WDC 65C02 contains all the added instructions of the Rockwell Synertek — `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB`, the (zp) addressing mode — and adds `BBR`, `BBS`, `RMB` and `SMB`.
+Test data for the Rockwell 65C02 microprocessor.
 
-10,000 tests are provided per opcode. All tests assume a full 64kb of RAM is mapped to the processor.
+This version of the 65C02 contains all of the added instructions of the Rockwell Synertek: `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB`, `BBR`, `BBS`, `RMB`, `SMB`, and the (zp) addressing mode.
 
-Sample test:
+# Guide
 
-	{
-		"name": "b1 28 b5",
-		"initial": {
-			"pc": 59082,
-			"s": 39,
-			"a": 57,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[40, 160],
-				[41, 233],
-				[59982, 119]
-			]
-		},
-		"final": {
-			"pc": 59084,
-			"s": 39,
-			"a": 119,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[40, 160],
-				[41, 233],
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[59982, 119]
-			]
-		},
-		"cycles": [
-			[59082, 177, "read"],
-			[59083, 40, "read"],
-			[40, 160, "read"],
-			[41, 233, "read"],
-			[59083, 40, "read"],
-			[59982, 119, "read"]
+Within each `.json` file, there is a JSON array of 10,000 test scenarios.
+
+Each file corresponds to each of the instruction opcodes. (e.g. `a9.json` stores all of the tests for the LDA immediate instruction)
+
+Each test contains a `name` string, which can be ignored, and three major sections:
+* `initial` - the initial state of the processor
+* `final` - the expected final state of the processor
+* `cycles` - a list of expected bus operations for each cycle of the instruction
+  * each cycle is in the form of `[address, value, type]` where `type` is either `"read"` or `"write"`
+
+## Memory
+
+All tests assume the entire 64KiB memory space is RAM. In order to perform these tests, you may need to write a separate memory map for your emulator.
+
+The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
+
+Memory at any address besides those listed in the test, are expected to contain zeros.
+
+## Test Procedure
+
+First use a JSON parser to parse one of the `.json` files into an array/list of individual tests.
+
+Then for each test:
+1. Initialize your emulator's processor and memory with the `initial` state data provided by the test.
+2. Step your emulator forward until the processor completes **one instruction** worth of cycles.
+3. (Optional) After each cycle, compare your processor's last bus operation against the corresponding cycle from the `cycles` list.
+4. Once the instruction is complete, compare the test's expected `final` state with your emulator's state. If everything matches, you've passed the test!
+
+If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
+
+## Example
+
+Below is an example of a single test:
+```JSON
+{
+	"name": "b1 28 b5",
+	"initial": {
+		"pc": 59082,
+		"s": 39,
+		"a": 57,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[40, 160],
+			[41, 233],
+			[59982, 119]
 		]
-	}
-
-`name` is provided for human consumption and has no formal meaning.
-
-`initial` is the initial state of the processor; `ram` contains a list of values to store in memory prior to execution, each one in the form `[address, value]`.
-
-`final` is the state of the processor and relevant memory contents after execution.
-
-`cycles` provides a cycle-by-cycle breakdown of bus activity in the form `[address, value, type]` where `type` is either `read` or `write`.
+	},
+	"final": {
+		"pc": 59084,
+		"s": 39,
+		"a": 119,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[40, 160],
+			[41, 233],
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[59982, 119]
+		]
+	},
+	"cycles": [
+		[59082, 177, "read"],
+		[59083, 40, "read"],
+		[40, 160, "read"],
+		[41, 233, "read"],
+		[59083, 40, "read"],
+		[59982, 119, "read"]
+	]
+}
+```

--- a/rockwell65c02/README.md
+++ b/rockwell65c02/README.md
@@ -36,6 +36,8 @@ Then for each test:
 
 If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
 
+If you do perform step #3, also ensure only **one** bus operation occurs per cycle.
+
 ## Example
 
 Below is an example of a single test:

--- a/synertek65c02/README.md
+++ b/synertek65c02/README.md
@@ -36,6 +36,8 @@ Then for each test:
 
 If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
 
+If you do perform step #3, also ensure only **one** bus operation occurs per cycle.
+
 ## Example
 
 Below is an example of a single test:

--- a/synertek65c02/README.md
+++ b/synertek65c02/README.md
@@ -1,59 +1,86 @@
 # Synertek 65C02
 
-The Synertek 65C02 adds `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB` and the (zp) addressing mode to the 6502. It's sometimes referred to as the 65SC02.
+Test data for the Synertek 65C02 microprocessor.
 
-10,000 tests are provided per opcode. All tests assume a full 64kb of RAM is mapped to the processor.
+Sometimes called the 65SC02, this version of the 65C02 adds the `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB` instructions and the (zp) addressing mode to the 6502.
 
-Sample test:
+# Guide
 
-	{
-		"name": "b1 28 b5",
-		"initial": {
-			"pc": 59082,
-			"s": 39,
-			"a": 57,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[40, 160],
-				[41, 233],
-				[59982, 119]
-			]
-		},
-		"final": {
-			"pc": 59084,
-			"s": 39,
-			"a": 119,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[40, 160],
-				[41, 233],
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[59982, 119]
-			]
-		},
-		"cycles": [
-			[59082, 177, "read"],
-			[59083, 40, "read"],
-			[40, 160, "read"],
-			[41, 233, "read"],
-			[59083, 40, "read"],
-			[59982, 119, "read"]
+Within each `.json` file, there is a JSON array of 10,000 test scenarios.
+
+Each file corresponds to each of the instruction opcodes. (e.g. `a9.json` stores all of the tests for the LDA immediate instruction)
+
+Each test contains a `name` string, which can be ignored, and three major sections:
+* `initial` - the initial state of the processor
+* `final` - the expected final state of the processor
+* `cycles` - a list of expected bus operations for each cycle of the instruction
+  * each cycle is in the form of `[address, value, type]` where `type` is either `"read"` or `"write"`
+
+## Memory
+
+All tests assume the entire 64KiB memory space is RAM. In order to perform these tests, you may need to write a separate memory map for your emulator.
+
+The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
+
+Memory at any address besides those listed in the test, are expected to contain zeros.
+
+## Test Procedure
+
+First use a JSON parser to parse one of the `.json` files into an array/list of individual tests.
+
+Then for each test:
+1. Initialize your emulator's processor and memory with the `initial` state data provided by the test.
+2. Step your emulator forward until the processor completes **one instruction** worth of cycles.
+3. (Optional) After each cycle, compare your processor's last bus operation against the corresponding cycle from the `cycles` list.
+4. Once the instruction is complete, compare the test's expected `final` state with your emulator's state. If everything matches, you've passed the test!
+
+If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
+
+## Example
+
+Below is an example of a single test:
+```JSON
+{
+	"name": "b1 28 b5",
+	"initial": {
+		"pc": 59082,
+		"s": 39,
+		"a": 57,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[40, 160],
+			[41, 233],
+			[59982, 119]
 		]
-	}
-
-`name` is provided for human consumption and has no formal meaning.
-
-`initial` is the initial state of the processor; `ram` contains a list of values to store in memory prior to execution, each one in the form `[address, value]`.
-
-`final` is the state of the processor and relevant memory contents after execution.
-
-`cycles` provides a cycle-by-cycle breakdown of bus activity in the form `[address, value, type]` where `type` is either `read` or `write`.
+	},
+	"final": {
+		"pc": 59084,
+		"s": 39,
+		"a": 119,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[40, 160],
+			[41, 233],
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[59982, 119]
+		]
+	},
+	"cycles": [
+		[59082, 177, "read"],
+		[59083, 40, "read"],
+		[40, 160, "read"],
+		[41, 233, "read"],
+		[59083, 40, "read"],
+		[59982, 119, "read"]
+	]
+}
+```

--- a/wdc65c02/README.md
+++ b/wdc65c02/README.md
@@ -38,6 +38,8 @@ Then for each test:
 
 If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
 
+If you do perform step #3, also ensure only **one** bus operation occurs per cycle.
+
 ## Example
 
 Below is an example of a single test:

--- a/wdc65c02/README.md
+++ b/wdc65c02/README.md
@@ -1,61 +1,88 @@
 # WDC 65C02
 
-The WDC 65C02 contains all the added instructions of the Rockwell and the Synertek — `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB`, the (zp) addressing mode, `BBR`, `BBS`, `RMB` and `SMB` — and adds `STP` and `WAI`.
+Test data for the WDC 65C02 microprocessor.
 
-10,000 tests are provided per opcode. All tests assume a full 64kb of RAM is mapped to the processor.
+This version of the 65C02 contains all of the added instructions of both the Rockwell and Synertek: `P[H/L][X/Y]`, `STZ`, `TRB`, `TSB`, `BBR`, `BBS`, `RMB`, `SMB`, `STP`, `WAI`, and the (zp) addressing mode.
 
-`STP` and `WAI` are omitted here as incompatible with this style of testing.
+However, `STP` and `WAI` are omitted here as they're incompatible with this style of testing.
 
-Sample test:
+# Guide
 
-	{
-		"name": "b1 28 b5",
-		"initial": {
-			"pc": 59082,
-			"s": 39,
-			"a": 57,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[40, 160],
-				[41, 233],
-				[59982, 119]
-			]
-		},
-		"final": {
-			"pc": 59084,
-			"s": 39,
-			"a": 119,
-			"x": 33,
-			"y": 174,
-			"p": 96,
-			"ram": [
-				[40, 160],
-				[41, 233],
-				[59082, 177],
-				[59083, 40],
-				[59084, 181],
-				[59982, 119]
-			]
-		},
-		"cycles": [
-			[59082, 177, "read"],
-			[59083, 40, "read"],
-			[40, 160, "read"],
-			[41, 233, "read"],
-			[59083, 40, "read"],
-			[59982, 119, "read"]
+Within each `.json` file, there is a JSON array of 10,000 test scenarios.
+
+Each file corresponds to each of the instruction opcodes. (e.g. `a9.json` stores all of the tests for the LDA immediate instruction)
+
+Each test contains a `name` string, which can be ignored, and three major sections:
+* `initial` - the initial state of the processor
+* `final` - the expected final state of the processor
+* `cycles` - a list of expected bus operations for each cycle of the instruction
+  * each cycle is in the form of `[address, value, type]` where `type` is either `"read"` or `"write"`
+
+## Memory
+
+All tests assume the entire 64KiB memory space is RAM. In order to perform these tests, you may need to write a separate memory map for your emulator.
+
+The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
+
+Memory at any address besides those listed in the test, are expected to contain zeros.
+
+## Test Procedure
+
+First use a JSON parser to parse one of the `.json` files into an array/list of individual tests.
+
+Then for each test:
+1. Initialize your emulator's processor and memory with the `initial` state data provided by the test.
+2. Step your emulator forward until the processor completes **one instruction** worth of cycles.
+3. (Optional) After each cycle, compare your processor's last bus operation against the corresponding cycle from the `cycles` list.
+4. Once the instruction is complete, compare the test's expected `final` state with your emulator's state. If everything matches, you've passed the test!
+
+If you aren't emulating individual cycles (skipped step #3), you can still count how many elements are contained in the `cycles` list and compare with the number of cycles your emulator should have taken to perform the instruction.
+
+## Example
+
+Below is an example of a single test:
+```JSON
+{
+	"name": "b1 28 b5",
+	"initial": {
+		"pc": 59082,
+		"s": 39,
+		"a": 57,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[40, 160],
+			[41, 233],
+			[59982, 119]
 		]
-	}
-
-`name` is provided for human consumption and has no formal meaning.
-
-`initial` is the initial state of the processor; `ram` contains a list of values to store in memory prior to execution, each one in the form `[address, value]`.
-
-`final` is the state of the processor and relevant memory contents after execution.
-
-`cycles` provides a cycle-by-cycle breakdown of bus activity in the form `[address, value, type]` where `type` is either `read` or `write`.
+	},
+	"final": {
+		"pc": 59084,
+		"s": 39,
+		"a": 119,
+		"x": 33,
+		"y": 174,
+		"p": 96,
+		"ram": [
+			[40, 160],
+			[41, 233],
+			[59082, 177],
+			[59083, 40],
+			[59084, 181],
+			[59982, 119]
+		]
+	},
+	"cycles": [
+		[59082, 177, "read"],
+		[59083, 40, "read"],
+		[40, 160, "read"],
+		[41, 233, "read"],
+		[59083, 40, "read"],
+		[59982, 119, "read"]
+	]
+}
+```


### PR DESCRIPTION
These tests have become quite popular and are frequently recommended to new developers. They have become and invaluable resource for the emudev community!

However, from my experience in the Emulator Development discord server, I've noticed it is not uncommon for developers to ask how these tests should be used or implemented. There have even been some rare cases where developers have found these tests, but decided to skip them as they weren't sure how to make use of them.

To hopefully eliminate any confusion, I've written up a short guide in each README. It gives an overview of the architecture (paraphrased from the current READMEs), the layout of the test data, and step-by-step instructions for implementing a test procedure.

---

Side note, the Rockwell README [call itself the WDC 65C02](https://github.com/SingleStepTests/65x02/blob/3ecec7e679e629622019707655416b8767a65f95/rockwell65c02/README.md?plain=1#L3). I'm not an expert in these versions of the 65C02, but this seemed a bit misleading since the wdc65C02 README used the same term. Couldn't find a clear answer online. So I just used "Rockwell 65C02" [instead](https://github.com/bigbass1997/65x02/blob/6c8313688a6f235befa07b028106ba97e2315c40/rockwell65c02/README.md?plain=1#L3).