### PR TITLE
Clarified expectations regarding RAM accesses

### DIFF
--- a/6502/README.md
+++ b/6502/README.md
@@ -22,7 +22,7 @@ All tests assume the entire 64KiB memory space is RAM. In order to perform these
 
 The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
 
-Memory at any address besides those listed in the test, are expected to contain zeros.
+Any memory address not included in a test's `ram` lists must not be accessed during that test. However, there may be memory addresses in the `ram` lists that are never accessed during the test.
 
 ## Test Procedure
 

--- a/nes6502/README.md
+++ b/nes6502/README.md
@@ -24,7 +24,7 @@ All tests assume the entire 64KiB memory space is RAM. Since this is different f
 
 The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
 
-Memory at any address besides those listed in the test, are expected to contain zeros.
+Any memory address not included in a test's `ram` lists must not be accessed during that test. However, there may be memory addresses in the `ram` lists that are never accessed during the test.
 
 ## Test Procedure
 

--- a/rockwell65c02/README.md
+++ b/rockwell65c02/README.md
@@ -22,7 +22,7 @@ All tests assume the entire 64KiB memory space is RAM. In order to perform these
 
 The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
 
-Memory at any address besides those listed in the test, are expected to contain zeros.
+Any memory address not included in a test's `ram` lists must not be accessed during that test. However, there may be memory addresses in the `ram` lists that are never accessed during the test.
 
 ## Test Procedure
 

--- a/synertek65c02/README.md
+++ b/synertek65c02/README.md
@@ -22,7 +22,7 @@ All tests assume the entire 64KiB memory space is RAM. In order to perform these
 
 The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
 
-Memory at any address besides those listed in the test, are expected to contain zeros.
+Any memory address not included in a test's `ram` lists must not be accessed during that test. However, there may be memory addresses in the `ram` lists that are never accessed during the test.
 
 ## Test Procedure
 

--- a/wdc65c02/README.md
+++ b/wdc65c02/README.md
@@ -24,7 +24,7 @@ All tests assume the entire 64KiB memory space is RAM. In order to perform these
 
 The `ram` elements inside the `initial` and `final` sections of the test, are in the form of `[address, value]`.
 
-Memory at any address besides those listed in the test, are expected to contain zeros.
+Any memory address not included in a test's `ram` lists must not be accessed during that test. However, there may be memory addresses in the `ram` lists that are never accessed during the test.
 
 ## Test Procedure
 


### PR DESCRIPTION
It appears I misunderstood the implications of addresses included and excluded from the `ram` lists in each test.

My previous impression was that any memory location with a zero was _equivalent_ to any memory location not explicitly included in the list. As such, it appeared that zeros weren't very meaningful.

However, it has come to my attention via comments from @Estus-Dev and @gulrak that there are some expectations that I didn't notice:
* Addresses _excluded_ from the `ram` lists, _must not_ be accessed during the test
* Addresses _included_ in the `ram` lists, _may never_ be accessed during the test

From some testing, these assertions appear to be correct, at least for the nes6502 set. The example test even includes a case of the second rule already.

This PR adds a clarification to the README to hopefully better explain these rules.